### PR TITLE
Removed the .cr extension from the shard name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add this to your application's `shard.yml`:
 
 ```yaml
 dependencies:
-  europe.cr:
+  europe:
     github: VvanGemert/europe.cr
 ```
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: europe.cr
+name: europe
 
 version: 0.1.9
 

--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ version: 0.1.9
 authors:
   - vvangemert <vincent@floorplanner.com>
 
-crystal: 0.32.1
+crystal: 0.33.0
 
 license: MIT
 


### PR DESCRIPTION
This fixes #1. As it turns out, the lib name can't have an extension. Removing it fixed the issue. 🤓️

BTW: I tested this shard with Crystal v0.33.0 and no issues there. So, the README can be updated as well.